### PR TITLE
feat: support showing commits and logging

### DIFF
--- a/lua/sapling_scm/client.lua
+++ b/lua/sapling_scm/client.lua
@@ -1,5 +1,8 @@
 local client = {}
 
+local SHOW_COMMAND = [[sl show -Tjson '%s']]
+local LOG_COMMAND = [[sl log -r '%s']]
+
 ---@class HeadInfo
 ---@field node string
 ---@field remotenames string[]
@@ -12,6 +15,32 @@ local client = {}
 client.head_info = function()
   local head_info = vim.fn.system [[sl log -r '.' -T"{dict(remotenames,node,peerurls)|json}"]]
   return vim.json.decode(head_info)
+end
+
+---@class ShowResult
+---@field node string
+---@field date table<number, number>
+---@field user string
+---@field phase string
+---@field desc string
+---@field diff string
+
+--- Gets info about a single commit
+--
+---@param commit string The commit like to show
+---@return ShowResult
+client.show = function(commit)
+  local result = vim.fn.system(SHOW_COMMAND:format(commit))
+  local decoded = vim.json.decode(result)
+
+  return decoded[1]
+end
+
+--- Runs the sapling log command and returns the output as a list of strings.
+--
+---@return string[]
+client.log_text = function(pattern)
+  return vim.fn.systemlist(LOG_COMMAND:format(pattern))
 end
 
 return client

--- a/lua/sapling_scm/fs.lua
+++ b/lua/sapling_scm/fs.lua
@@ -1,0 +1,89 @@
+local client = require "sapling_scm.client"
+
+-- Test to see if we have baleia installed. If we do we can use it to highlight
+-- ansi colors from command output.
+local has_baleia, baleia = pcall(function()
+  return require("baleia").setup { name = "SaplingColors" }
+end)
+
+-- Highlight the buffer using baleia if it is installed.
+local highlight_buffer = function(buf)
+  if has_baleia then
+    baleia.once(buf)
+  end
+end
+
+---@alias action "show" | "log"
+
+---@class ShowAction
+---@field action "show"
+---@field commit string
+--
+---@class LogAction
+---@field action "log"
+---@field pattern string
+
+---@param url string
+---@return ShowAction | LogAction | nil
+local parse_url = function(url)
+  local show_matches = url:match "sl://show/(.*)"
+  if show_matches then
+    return { action = "show", commit = show_matches }
+  end
+
+  local log_matches = url:match "sl://log/(.*)"
+  if log_matches then
+    return { action = "log", pattern = log_matches }
+  end
+
+  -- No handler for this url is found
+  return nil
+end
+
+---@param url string
+---@param buf integer
+local handle = function(url, buf)
+  local action = parse_url(url)
+
+  vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
+
+  if not action then
+    -- TODO(AdeAttwood): Handle this case with an error buffer
+    return
+  end
+
+  if action.action == "show" then
+    local commit = client.show(action.commit)
+
+    vim.api.nvim_buf_set_option(buf, "filetype", "diff")
+
+    local header = {
+      "# Node: " .. commit.node,
+      "# Author: " .. commit.user,
+      "# Date: " .. os.date("%c", commit.date[1]),
+      "#",
+    }
+
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, header)
+
+    local index = #header + 1
+
+    local desc = vim.split(commit.desc, "\n")
+    for _, line in ipairs(desc) do
+      vim.api.nvim_buf_set_lines(buf, index, -1, false, { "# " .. line })
+      index = index + 1
+    end
+
+    vim.api.nvim_buf_set_lines(buf, index, -1, false, vim.split(commit.diff, "\n"))
+  end
+
+  if action.action == "log" then
+    local log = client.log_text(action.pattern)
+
+    vim.api.nvim_buf_set_option(buf, "filetype", "saplinglog")
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, log)
+    highlight_buffer(buf)
+  end
+end
+
+return { handle = handle }

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -1,5 +1,22 @@
 local client = require "sapling_scm.client"
 local remote_url = require "sapling_scm.remote_url"
+local fs = require "sapling_scm.fs"
+
+vim.api.nvim_create_autocmd("BufReadCmd", {
+  pattern = { "sl://*" },
+  callback = function(event)
+    fs.handle(event.file, event.buf)
+  end,
+  desc = "Sapling SCM URL handler",
+})
+
+vim.api.nvim_create_user_command("Sshow", function(props)
+  vim.cmd("edit sl://show/" .. props.args)
+end, { nargs = "+", desc = "Browse the current object on the remote url" })
+
+vim.api.nvim_create_user_command("Slog", function(props)
+  vim.cmd("edit sl://log/" .. props.args)
+end, { nargs = "+", desc = "Browse the current object on the remote url" })
 
 vim.api.nvim_create_user_command("Sbrowse", function(props)
   local file = vim.fn.expand "%"


### PR DESCRIPTION
feat: support showing commits and logging

Summary:

Create two new commands, "Sshow" and "Slog" they will run the sapling show and
log commands. All the output will be put info a buffer. This is all implemented
using the `BufReadCmd` auto command so it can be easily expanded.

The show command will load the diff info a buffer with the details and
description at the top of the buffer in comments. The file will be a diff
filetype so its recommended to treesitter for nice diff highlighting

The log command will run `sl log` with your given ref and put the output in a
buffer. Right how we are loading the raw output of the command in the buffer,
all highlighting is done with baleia. This will escape your ansi output and
provide the correct colors. This uses the default log command so the output can
be configured in sapling with `ui.logtemplate`

Test Plan:

Right now there is no testing for this. I will in the future set this up in CI.
Because this project is very early I would like to have a bit more of a history
before we start using it for testing.
