### PR TITLE
feat: all the ability to view diff from the log

### DIFF
--- a/lua/sapling_scm/log_actions.lua
+++ b/lua/sapling_scm/log_actions.lua
@@ -1,0 +1,13 @@
+local actions = {}
+
+---@return string
+local get_hash_from_line = function()
+  return vim.api.nvim_get_current_line():match "[0-9a-f]+"
+end
+
+actions.show_current_hash = function()
+  local hash = get_hash_from_line()
+  vim.cmd("edit sl://show/" .. hash)
+end
+
+return actions

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -1,6 +1,7 @@
 local client = require "sapling_scm.client"
 local remote_url = require "sapling_scm.remote_url"
 local fs = require "sapling_scm.fs"
+local log_actions = require "sapling_scm.log_actions"
 
 vim.api.nvim_create_autocmd("BufReadCmd", {
   pattern = { "sl://*" },
@@ -8,6 +9,13 @@ vim.api.nvim_create_autocmd("BufReadCmd", {
     fs.handle(event.file, event.buf)
   end,
   desc = "Sapling SCM URL handler",
+})
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "saplinglog",
+  callback = function(args)
+    vim.keymap.set("n", "<CR>", log_actions.show_current_hash, { buffer = args.buf })
+  end,
 })
 
 vim.api.nvim_create_user_command("Sshow", function(props)


### PR DESCRIPTION
feat: all the ability to view diff from the log

Summary:

Now when you are in the sapling log you can push `<CR>` (Enter) on a log line
and it will open the diff of that line. This makes it really easy to view the
changes in your current stack.

I think soon we will think about running other commands while you are in this
buffer.

Test Plan:

No tests for now. I have been using this so thats the best we got ATM.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/sapling.nvim/pull/3).
* #4
* __->__ #3