### PR TITLE
feat: add annotate command to view commits of lines

### DIFF
--- a/lua/sapling_scm/client.lua
+++ b/lua/sapling_scm/client.lua
@@ -43,4 +43,30 @@ client.log_text = function(pattern)
   return vim.fn.systemlist(LOG_COMMAND:format(pattern))
 end
 
+-- Runs `sl annotate` and returns the contents without the line contents. It
+-- will also return the length of the longest item so you can create a window
+-- the same length of its contents. You will also need to specify the ref of
+-- the file so it annotates the correct version.
+--
+---@return number, string[]
+client.annotate = function(ref, file)
+  local annotate_command = vim.fn.systemlist(string.format("sl annotate -r '%s' '%s'", ref, file))
+  local width = 0
+  local result = {}
+
+  for _, line in ipairs(annotate_command) do
+    local parts = vim.split(line, ":")
+    local ref_date_and_user = parts[1]
+    local part_size = #ref_date_and_user
+
+    if part_size > width then
+      width = part_size
+    end
+
+    table.insert(result, ref_date_and_user)
+  end
+
+  return width, result
+end
+
 return client

--- a/lua/sapling_scm/log_actions.lua
+++ b/lua/sapling_scm/log_actions.lua
@@ -1,0 +1,13 @@
+local actions = {}
+
+---@return string
+local get_hash_from_line = function()
+  return vim.api.nvim_get_current_line():match "[0-9a-f]+"
+end
+
+actions.show_current_hash = function()
+  local hash = get_hash_from_line()
+  vim.cmd("edit sl://show/" .. hash)
+end
+
+return actions

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -1,6 +1,7 @@
 local client = require "sapling_scm.client"
 local remote_url = require "sapling_scm.remote_url"
 local fs = require "sapling_scm.fs"
+local log_actions = require "sapling_scm.log_actions"
 
 vim.api.nvim_create_autocmd("BufReadCmd", {
   pattern = { "sl://*" },
@@ -8,6 +9,13 @@ vim.api.nvim_create_autocmd("BufReadCmd", {
     fs.handle(event.file, event.buf)
   end,
   desc = "Sapling SCM URL handler",
+})
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "saplinglog",
+  callback = function(args)
+    vim.keymap.set("n", "<CR>", log_actions.show_current_hash, { buffer = args.buf })
+  end,
 })
 
 vim.api.nvim_create_user_command("Sshow", function(props)

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -26,6 +26,21 @@ vim.api.nvim_create_user_command("Slog", function(props)
   vim.cmd("edit sl://log/" .. props.args)
 end, { nargs = "+", desc = "Browse the current object on the remote url" })
 
+vim.api.nvim_create_user_command("Sannotate", function()
+  local width, annotations = client.annotate(".", vim.api.nvim_buf_get_name(0))
+
+  vim.cmd "set cursorbind"
+
+  vim.cmd(string.format("vert topleft split | vertical resize %d | e /tmp/annotations", width))
+  vim.api.nvim_buf_set_option(0, "buftype", "nofile")
+  vim.api.nvim_win_set_option(0, "number", false)
+  vim.api.nvim_win_set_option(0, "relativenumber", false)
+  vim.api.nvim_win_set_option(0, "signcolumn", "no")
+
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, annotations)
+  vim.cmd "set cursorbind"
+end, { desc = "Browse the current object on the remote url" })
+
 vim.api.nvim_create_user_command("Sbrowse", function(props)
   local file = vim.fn.expand "%"
   local start_line = props.line1


### PR DESCRIPTION
feat: add annotate command to view commits of lines

Summary:

This will post the run the `sl annotate` command and put the output of the
command in a buffer to the left of the current one. This will use `cursorbind`
to keep the two buffers in sync and you will be able to see the change the line
was part of.

Test Plan:

Right now we still don't have any good tests. I will probally make getting this
setup in ci my next job for this plugin.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/sapling.nvim/pull/4).
* __->__ #4
* #3