### PR TITLE
test: add tests for Slog and Sdiff commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,16 @@ jobs:
       - name: Install busted
         run: sudo luarocks install busted
 
+      - name: Download sapling
+        uses: robinraju/release-downloader@v1.9
+        with:
+          repository: "facebook/sapling"
+          latest: true
+          fileName: "*amd64.Ubuntu22.04.deb"
+
+      - name: Install sapling
+        run: sudo dpkg --install *.deb
+
       - name: Install neovim
         run: |
           test -d _neovim || {
@@ -25,12 +35,17 @@ jobs:
             curl -sL "https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
 
+      - name: Clone the sapling.nvim repo
+        run: sl clone --git https://github.com/AdeAttwood/sapling.nvim.git _sapling.nvim
+
       - name: Run tests
         run: |
           export PATH="${PWD}/_neovim/bin:${PATH}"
           export VIM="${PWD}/_neovim/share/nvim/runtime"
+
+          cd _sapling.nvim
+
+          sl config --local ui.logtemplate ' {graphnode} {node|short} {truncatelonglines(desc|firstline, 80)} ({date|age}) <{author|person}> {if(github_pull_request_number, "PR #{github_pull_request_number}")}\n'
+
           nvim --version
-
-          nvim -l ./lua/sapling_scm_tests/init.lua
-
-
+          nvim -l ../lua/sapling_scm_tests/init.lua

--- a/lua/sapling_scm_tests/fs_spec.lua
+++ b/lua/sapling_scm_tests/fs_spec.lua
@@ -1,0 +1,84 @@
+require "sapling_scm_tests.setup"
+
+-- Run a vim command and get the output of the current buffer
+--
+---@param command string
+---@return string, string[]
+local run_command = function(command)
+  vim.cmd(command)
+
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  if not lines then
+    return "", {}
+  end
+
+  return vim.fn.join(lines, "\n"), lines
+end
+
+describe("Slog", function()
+  describe("with a single commit hash", function()
+    local content, lines = run_command "Slog f5bdd00322fe"
+
+    it("has only one line in the output", function()
+      assert.is_equal(1, #lines)
+    end)
+
+    it("has the commit sha in the output", function()
+      assert.matches("f5bdd00322fe", content)
+    end)
+
+    it("has the commit message in the buffer", function()
+      assert.matches("chore: initial commit", content)
+    end)
+
+    it("has the buffer file type set to saplinglog", function()
+      assert.is_equal("saplinglog", vim.bo.filetype)
+    end)
+  end)
+
+  describe("with a range of commits", function()
+    local content, lines = run_command "Slog f5bdd00322fe::73a8acee4819"
+
+    it("has multiple lines in the output", function()
+      assert.is_equal(3, #lines)
+    end)
+
+    it("has the first commit sha in the output", function()
+      assert.matches("f5bdd00322fe", content)
+    end)
+
+    it("has the first commit message in the output", function()
+      assert.matches("chore: initial commit", content)
+    end)
+
+    it("has the last commit sha in the output", function()
+      assert.matches("73a8acee4819", content)
+    end)
+
+    it("has the last commit message in the output", function()
+      assert.matches("feat: support showing commits and logging", content)
+    end)
+  end)
+end)
+
+describe("Sshow", function()
+  describe("with the first commit", function()
+    local content, _ = run_command "Sshow f5bdd00322fe"
+
+    it("has the full node in the output", function()
+      assert.matches("Node: f5bdd00322fea627d5dfa5de9180a37d22a51ce5", content)
+    end)
+
+    it("has the author in the output", function()
+      assert.matches("Author: Ade Attwood", content)
+    end)
+
+    it("has the diff printed in the buffer", function()
+      assert.matches("--git a/plugin/sapling_scm.lua", content)
+    end)
+
+    it("has the buffer file type set to diff", function()
+      assert.is_equal("diff", vim.bo.filetype)
+    end)
+  end)
+end)

--- a/lua/sapling_scm_tests/init.lua
+++ b/lua/sapling_scm_tests/init.lua
@@ -18,15 +18,15 @@ busted.subscribe({ "failure" }, function()
 end)
 
 busted.subscribe({ "exit" }, function()
-  if exit_code ~= 0 then
-    print "\n"
-    os.exit(exit_code)
-  end
+  os.exit(exit_code)
 
   return nil, true
 end)
 
 vim.opt.rtp:append(vim.fn.getcwd())
+vim.opt.rtp:append(vim.fn.getcwd() .. "/../")
+
+require "plugin.sapling_scm"
 
 for _, file in ipairs(test_files) do
   require(file:gsub(".lua", ""))


### PR DESCRIPTION
test: add tests for Slog and Sdiff commands

Summary:

This adds the base tests for sapling log and sapling diff. There are still more
we can do however this is a good start to making sure everything stays working.

Test Plan:

Ensure the tests run in CI
