### PR TITLE
feat: support metaedit and commiting

### DIFF
--- a/lua/sapling_scm/editor_command.lua
+++ b/lua/sapling_scm/editor_command.lua
@@ -1,0 +1,67 @@
+local editor_command = {}
+
+local edit_script = [[
+#!/bin/sh
+
+TMP_SCRIPT="%s"
+printf "sapling_edit:$1" >&2
+while [ ! -f "$TMP_SCRIPT.exit" ]; do sleep 0.05 2>/dev/null || sleep 1; done
+exit 0
+]]
+
+-- Write content to a file and return true if successful
+--
+---@return boolean
+local write_file = function(name, content)
+  local f = io.open(name, "w")
+  if not f then
+    return false
+  end
+
+  f:write(content)
+  f:close()
+
+  return true
+end
+
+-- Edits a file in the current nvim process and calls on_close when the buffer
+-- is closed.
+local edit_in_vim = function(file, on_close)
+  vim.cmd("edit " .. file)
+
+  vim.api.nvim_create_autocmd("BufUnload", {
+    buffer = 0,
+    callback = on_close,
+  })
+end
+
+-- Run a command that will require you to edit a file. For commands like
+-- metaedit and commit, this will open an editor. Because we are already in an
+-- editor, we will open the file in the current editor and do some tricks to
+-- pause the command until the file is closed.
+--
+---@param command string The command to run i.e. `sl commit`
+editor_command.run = function(command)
+  local tmp_file = os.tmpname() .. ".sapling-nvim"
+
+  write_file(tmp_file, string.format(edit_script, tmp_file))
+
+  vim.fn.jobstart(command, {
+    env = { EDITOR = "sh " .. tmp_file },
+    on_exit = function()
+      vim.cmd "edit %"
+    end,
+    on_stderr = function(_, data)
+      for _, v in ipairs(data) do
+        local file = string.match(v, "sapling_edit:(.*)")
+        if file then
+          edit_in_vim(file, function()
+            write_file(tmp_file .. ".exit", "")
+          end)
+        end
+      end
+    end,
+  })
+end
+
+return editor_command

--- a/lua/sapling_scm/log_actions.lua
+++ b/lua/sapling_scm/log_actions.lua
@@ -1,3 +1,4 @@
+local editor_command = require "sapling_scm.editor_command"
 local actions = {}
 
 ---@return string
@@ -8,6 +9,15 @@ end
 actions.show_current_hash = function()
   local hash = get_hash_from_line()
   vim.cmd("edit sl://show/" .. hash)
+end
+
+actions.metaedit = function()
+  local hash = get_hash_from_line()
+  editor_command.run(string.format("sl metaedit -r '%s'", hash))
+end
+
+actions.commit = function()
+  editor_command.run "sl commit -v"
 end
 
 return actions

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -15,6 +15,8 @@ vim.api.nvim_create_autocmd("FileType", {
   pattern = "saplinglog",
   callback = function(args)
     vim.keymap.set("n", "<CR>", log_actions.show_current_hash, { buffer = args.buf })
+    vim.keymap.set("n", "<C-e>", log_actions.metaedit, { buffer = args.buf })
+    vim.keymap.set("n", "<C-c>", log_actions.commit, { buffer = args.buf })
   end,
 })
 
@@ -40,6 +42,8 @@ vim.api.nvim_create_user_command("Sannotate", function()
   vim.api.nvim_buf_set_lines(0, 0, -1, false, annotations)
   vim.cmd "set cursorbind"
 end, { desc = "Browse the current object on the remote url" })
+
+vim.api.nvim_create_user_command("Scommit", log_actions.commit, { desc = "Commit all your current changes" })
 
 vim.api.nvim_create_user_command("Sbrowse", function(props)
   local file = vim.fn.expand "%"


### PR DESCRIPTION
feat: support metaedit and commiting

Summary:

You can not use the metaedit command and commit, from inside the nvim instance.
This will use the sl exe and some tricks to send the file that sapling wants to
edit back to the editor. We can then open the files up and start editing.

This will work by using "<C-e>" in the log buffer to edit the message that you
are currently on. To commit from inside the log buffer you can press "<C-c>" or
there is the "Scommit" user command that can be used from anywhere

Test Plan:

I have not attempted to write test for this one yet. I feel that will be a
little annoying as we are testing on the repo it self. I think if we want to
test this sort of stuff we will need to clone repos like we are doing in CI.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/sapling.nvim/pull/7).
* #8
* __->__ #7