### PR TITLE
feat: support status and diff commands

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -7,4 +7,4 @@ codes = true
 self = false
 
 -- Global objects defined by the C code
-read_globals = { "vim", "describe", "it", "assert" }
+read_globals = { "vim", "describe", "it", "assert", "teardown" }

--- a/lua/sapling_scm/client.lua
+++ b/lua/sapling_scm/client.lua
@@ -69,4 +69,34 @@ client.annotate = function(ref, file)
   return width, result
 end
 
+-- Run the diff command and return the output as a list of strings. If no param
+-- is passed then it will return the diff of your current changes.
+--
+---@param ref string | nil
+---@return string[]
+client.diff = function(ref)
+  if not ref or ref == "" then
+    return vim.fn.systemlist "sl diff --git"
+  end
+
+  return vim.fn.systemlist(string.format("sl diff %s", ref))
+end
+
+client.STATUS_MODIFIED = "M"
+client.STATUS_ADDED = "A"
+client.STATUS_UNTRACKED = "?"
+client.STATUS_REMOVED = "R"
+
+---@alias Status "M" | "A" | "?" | "R"
+
+---@class StatusItem
+---@field status Status
+---@field path string
+
+-- Returns output of `sl status` as an array..
+---@return StatusItem[]
+client.status = function()
+  return vim.json.decode(vim.fn.system "sl status -Tjson")
+end
+
 return client

--- a/lua/sapling_scm/fs.lua
+++ b/lua/sapling_scm/fs.lua
@@ -36,6 +36,15 @@ local parse_url = function(url)
     return { action = "log", pattern = log_matches }
   end
 
+  local diff_matcehs = url:match "sl://diff/(.*)"
+  if diff_matcehs then
+    return { action = "diff", pattern = diff_matcehs }
+  end
+
+  if url == "sl://status" then
+    return { action = "status" }
+  end
+
   -- No handler for this url is found
   return nil
 end
@@ -83,6 +92,22 @@ local handle = function(url, buf)
     vim.api.nvim_buf_set_option(buf, "filetype", "saplinglog")
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, log)
     highlight_buffer(buf)
+  end
+
+  if action.action == "diff" then
+    local diff = client.diff(action.pattern)
+    vim.api.nvim_buf_set_option(buf, "filetype", "diff")
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, diff)
+  end
+
+  if action.action == "status" then
+    local status = client.status()
+    vim.api.nvim_buf_set_option(buf, "filetype", "saplingstatus")
+
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "# Sapling status" })
+    for i, item in ipairs(status) do
+      vim.api.nvim_buf_set_lines(buf, i, -1, false, { item.status .. " " .. item.path })
+    end
   end
 end
 

--- a/lua/sapling_scm_tests/fs_spec.lua
+++ b/lua/sapling_scm_tests/fs_spec.lua
@@ -82,3 +82,49 @@ describe("Sshow", function()
     end)
   end)
 end)
+
+describe("Sdiff", function()
+  vim.fn.system "echo 'This is a line added' >> README.md"
+
+  local _, lines = run_command "Sdiff"
+
+  teardown(function()
+    vim.fn.system "sl revert README.md"
+  end)
+
+  it("has the line that has been changed in the output", function()
+    local found = false
+    for _, line in ipairs(lines) do
+      if line == "+This is a line added" then
+        found = true
+      end
+    end
+
+    assert.is_true(found)
+  end)
+end)
+
+describe("Sstatus", function()
+  vim.fn.system "echo 'This is a line added' >> README.md"
+
+  local _, lines = run_command "Sstatus"
+
+  teardown(function()
+    vim.fn.system "sl revert README.md"
+  end)
+
+  it("has the file in the buffer", function()
+    local found = false
+    for _, line in ipairs(lines) do
+      if line == "M README.md" then
+        found = true
+      end
+    end
+
+    assert.is_true(found)
+  end)
+
+  it("has the saplingstatus filetype", function()
+    assert.is_equal("saplingstatus", vim.bo.filetype)
+  end)
+end)

--- a/lua/sapling_scm_tests/setup.lua
+++ b/lua/sapling_scm_tests/setup.lua
@@ -3,3 +3,4 @@ local busted = require "busted"
 _G.describe = busted.describe
 _G.it = busted.it
 _G.assert = busted.assert
+_G.teardown = busted.teardown

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -28,6 +28,14 @@ vim.api.nvim_create_user_command("Slog", function(props)
   vim.cmd("edit sl://log/" .. props.args)
 end, { nargs = "+", desc = "Browse the current object on the remote url" })
 
+vim.api.nvim_create_user_command("Sdiff", function(props)
+  vim.cmd("edit sl://diff/" .. props.args)
+end, { nargs = "?", desc = "Browse the current object on the remote url" })
+
+vim.api.nvim_create_user_command("Sstatus", function()
+  vim.cmd "edit sl://status"
+end, { desc = "Browse the current object on the remote url" })
+
 vim.api.nvim_create_user_command("Sannotate", function()
   local width, annotations = client.annotate(".", vim.api.nvim_buf_get_name(0))
 


### PR DESCRIPTION
feat: support status and diff commands

Summary:

Now you get two extra command `Sdiff` and `Sstatus`. The status command is very
simple, it adds the output of `sl status` into a buffer so you can see what the
status of your current changes are. Right now there are no commands available
in this buffer, we gota start somewhere.

The diff command will by default with no args will show the diff of your
current changes. Any args passed to this will be passed on to the diff command
to give you as much flexibility as we can.

Test Plan:

This one has been unit tested and test manually, so we can let the ci sort this
one out.
