### PR TITLE
feat: add bookmark when viewing logs

### DIFF
--- a/doc/sapling-scm.txt
+++ b/doc/sapling-scm.txt
@@ -15,6 +15,7 @@ CONTENTS                                                *sapling-scm-contents*
 3. Log Actions                                       |sapling-scm-log-actions|
   3.1 View                                              |sapling-scm-log-view|
   3.2 Metaedit                                      |sapling-scm-log-metaedit|
+  3.3 Bookmark                                      |sapling-scm-log-bookmark|
 
 ==============================================================================
 INTRO                                                     *sapling-scm-intro*
@@ -101,5 +102,14 @@ Metaedit  <C-e>                                     |sapling-scm-log-metaedit|
 
 Editing the metadata of a commit will open a new buffer with old metadata in
 it. When you then save and close the buffer the metadata will be updated.
+
+Bookmark  <C-b>                                     |sapling-scm-log-bookmark|
+
+Add a bookmark to a commit. When using the keybinding it will ask you to input
+the bookmark name. One you have given your name its will apply the bookmark
+using `sl bookmark` behind the scenes.
+
+NOTE: If you are using tmux with <C-b> as the leader key, you may been to use
+<C-bb> to add a bookmark.
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/sapling_scm/log_actions.lua
+++ b/lua/sapling_scm/log_actions.lua
@@ -16,6 +16,16 @@ actions.metaedit = function()
   editor_command.run(string.format("sl metaedit -r '%s'", hash))
 end
 
+actions.bookmark = function()
+  local hash = get_hash_from_line()
+  vim.ui.input({ prompt = "Bookmark name for " .. hash .. ": " }, function(name)
+    if name then
+      editor_command.run(string.format("sl bookmark -f -r '%s' '%s'", hash, name))
+      vim.cmd "edit %"
+    end
+  end)
+end
+
 actions.commit = function()
   editor_command.run "sl commit -v"
 end

--- a/lua/sapling_scm_tests/log_actions_spec.lua
+++ b/lua/sapling_scm_tests/log_actions_spec.lua
@@ -1,0 +1,56 @@
+require "sapling_scm_tests.setup"
+
+local actions = require "sapling_scm.log_actions"
+local editor_command = require "sapling_scm.editor_command"
+
+local stub = require("busted").stub
+local match = require("busted").match
+
+describe("bookmark", function()
+  vim.cmd "edit sl://show/."
+  stub(editor_command, "run")
+
+  teardown(function()
+    editor_command.run:revert()
+  end)
+
+  describe("with no bookmark added in the input", function()
+    stub(vim.ui, "input", function(_, callback)
+      callback(nil)
+    end)
+
+    teardown(function()
+      vim.ui.input:revert()
+    end)
+
+    actions.bookmark()
+
+    it("calls vim.ui.input when the bookmark is called", function()
+      assert.stub(vim.ui.input).was_called_with(match.is_table(), match.is_function())
+    end)
+
+    it("dose not call the editor_command.run", function()
+      assert.stub(editor_command.run).was_not_called()
+    end)
+  end)
+
+  describe("with a name in the callback for the input", function()
+    stub(vim.ui, "input", function(_, callback)
+      callback "MY_BOOKMARK"
+    end)
+
+    teardown(function()
+      vim.ui.input:revert()
+    end)
+
+    actions.bookmark()
+
+    it("calls vim.ui.input when the bookmark is called", function()
+      assert.stub(vim.ui.input).was_called_with(match.is_table(), match.is_function())
+    end)
+
+    it("calls the editor command to create a bookmark", function()
+      assert.stub(editor_command.run).was_called_with(match.has_match "sl bookmark")
+    end)
+  end)
+end)

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -18,6 +18,7 @@ vim.api.nvim_create_autocmd("FileType", {
     vim.keymap.set("n", "<CR>", log_actions.show_current_hash, ops)
     vim.keymap.set("n", "<C-e>", log_actions.metaedit, ops)
     vim.keymap.set("n", "<C-c>", log_actions.commit, ops)
+    vim.keymap.set("n", "<C-b>", log_actions.bookmark, ops)
   end,
 })
 


### PR DESCRIPTION
feat: add bookmark when viewing logs

Summary:

Now when you are on a log buffer you can use <C-b> to add a bookmark to the
current node.

Test Plan:

Tests have been added and we have CI. I have also been using this for quite a
while now locally.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/sapling.nvim/pull/11).
* #12
* __->__ #11