### PR TITLE
feat: add go_to action to log view

### DIFF
--- a/lua/sapling_scm/log_actions.lua
+++ b/lua/sapling_scm/log_actions.lua
@@ -26,6 +26,11 @@ actions.bookmark = function()
   end)
 end
 
+actions.go_to = function()
+  local hash = get_hash_from_line()
+  editor_command.run(string.format("sl goto -r '%s'", hash))
+end
+
 actions.commit = function()
   editor_command.run "sl commit -v"
 end

--- a/lua/sapling_scm_tests/log_actions_spec.lua
+++ b/lua/sapling_scm_tests/log_actions_spec.lua
@@ -54,3 +54,24 @@ describe("bookmark", function()
     end)
   end)
 end)
+
+describe("goto", function()
+  vim.cmd "edit sl://show/."
+  stub(editor_command, "run")
+
+  teardown(function()
+    editor_command.run:revert()
+  end)
+
+  describe("with no bookmark added in the input", function()
+    actions.go_to()
+
+    it("calls the editor command with the correct command", function()
+      assert.stub(editor_command.run).was_called_with(match.has_match "sl goto")
+    end)
+
+    it("calls the editor command passing in the ref flag with a ref", function()
+      assert.stub(editor_command.run).was_called_with(match.has_match "-r '.*'")
+    end)
+  end)
+end)

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -19,6 +19,7 @@ vim.api.nvim_create_autocmd("FileType", {
     vim.keymap.set("n", "<C-e>", log_actions.metaedit, ops)
     vim.keymap.set("n", "<C-c>", log_actions.commit, ops)
     vim.keymap.set("n", "<C-b>", log_actions.bookmark, ops)
+    vim.keymap.set("n", "<C-g>", log_actions.go_to, ops)
   end,
 })
 


### PR DESCRIPTION
feat: add go_to action to log view

Summary:

When pressing ctrl-g in the log view, `sl goto` will be run with the current
ref. The the buffer will then be updated to reflect the new history changes.

Its uesful to use log queries that will find the full stack rather than up to
your current commit. This way when the buffer is updated commits dose disappear
and you can get back to where you were.

Test Plan:

Tests have been added and CI should pass.
