### PR TITLE
ci: replace actions/clone with sl clone

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,6 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install luarocks
-        run: sudo apt update && sudo apt install -y luarocks
-
-      - name: Install busted
-        run: sudo luarocks install busted
-
       - name: Download sapling
         uses: robinraju/release-downloader@v1.9
         with:
@@ -28,6 +19,23 @@ jobs:
       - name: Install sapling
         run: sudo dpkg --install *.deb
 
+      - name: Clean up the sapling deb file
+        run: rm ./*.deb
+
+      - name: Clone the repo
+        run: |
+          sl clone --git "https://github.com/${{ github.repository }}.git" ${{ github.workspace }}
+
+          head_node="$(sl log -r '.' -T"{node}")"
+          sl goto "${{ github.sha }}"
+          sl rebase -d "${head_node}"
+
+      - name: Install luarocks
+        run: sudo apt update && sudo apt install -y luarocks
+
+      - name: Install busted
+        run: sudo luarocks install busted
+
       - name: Install neovim
         run: |
           test -d _neovim || {
@@ -35,17 +43,12 @@ jobs:
             curl -sL "https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
 
-      - name: Clone the sapling.nvim repo
-        run: sl clone --git https://github.com/AdeAttwood/sapling.nvim.git _sapling.nvim
-
       - name: Run tests
         run: |
           export PATH="${PWD}/_neovim/bin:${PATH}"
           export VIM="${PWD}/_neovim/share/nvim/runtime"
 
-          cd _sapling.nvim
-
           sl config --local ui.logtemplate ' {graphnode} {node|short} {truncatelonglines(desc|firstline, 80)} ({date|age}) <{author|person}> {if(github_pull_request_number, "PR #{github_pull_request_number}")}\n'
 
           nvim --version
-          nvim -l ../lua/sapling_scm_tests/init.lua
+          nvim -l ./lua/sapling_scm_tests/init.lua


### PR DESCRIPTION
ci: replace actions/clone with sl clone

Summary:

When running CI we are using the incorrect tests in the repo. Because this
plugin needs to be in a sapling repo we clone the repo again. By doing this we
do not use the pull request changes but the head of the main branch.

Now we are ditching the actions/checkout and replacing it with `sl clone` in a
script. We are then checking out and rebasing the pull request changes on top
so we have the correct changes to test.

Test Plan:

This is it, if the CI passes then we are good to go.
