### PR TITLE
refactor: remote_url.blob to take path, ref and location

### DIFF
--- a/lua/sapling_scm/client.lua
+++ b/lua/sapling_scm/client.lua
@@ -3,7 +3,7 @@ local client = {}
 local SHOW_COMMAND = [[sl show -Tjson '%s']]
 local LOG_COMMAND = [[sl log -r '%s']]
 
----@class HeadInfo
+---@class CommitInfo
 ---@field node string
 ---@field remotenames string[]
 ---@field peerurls { [string]: string }
@@ -11,10 +11,10 @@ local LOG_COMMAND = [[sl log -r '%s']]
 -- Get the head info from the current repo, this is only the minimal info
 -- needed to create URLs.
 --
----@return HeadInfo
-client.head_info = function()
-  local head_info = vim.fn.system [[sl log -r '.' -T"{dict(remotenames,node,peerurls)|json}"]]
-  return vim.json.decode(head_info)
+---@return CommitInfo
+client.commit_info = function()
+  local commit_info = vim.fn.system [[sl log -r '.' -T"{dict(remotenames,node,peerurls)|json}"]]
+  return vim.json.decode(commit_info)
 end
 
 ---@class ShowResult
@@ -97,6 +97,14 @@ client.STATUS_REMOVED = "R"
 ---@return StatusItem[]
 client.status = function()
   return vim.json.decode(vim.fn.system "sl status -Tjson")
+end
+
+-- Gets an entry from the local config. You can pass in the dot separated path
+-- and it will return that value from the users local config of the repo.
+---@param path string
+---@return string
+client.config = function(path)
+  return vim.trim(vim.fn.system("sl config " .. path))
 end
 
 return client

--- a/lua/sapling_scm/fs.lua
+++ b/lua/sapling_scm/fs.lua
@@ -111,4 +111,4 @@ local handle = function(url, buf)
   end
 end
 
-return { handle = handle }
+return { handle = handle, parse_url = parse_url }

--- a/lua/sapling_scm/remote_url.lua
+++ b/lua/sapling_scm/remote_url.lua
@@ -1,23 +1,25 @@
 local remote_url = {}
 
----@param head_info HeadInfo
+---@param commit_info CommitInfo
 ---@return string
-local function get_object_ref(head_info)
-  if #head_info.remotenames > 0 then
-    local remote_name, _ = head_info.remotenames[1]:gsub("remote/", "")
+remote_url.get_object_ref = function(commit_info)
+  if #commit_info.remotenames > 0 then
+    local remote_name, _ = commit_info.remotenames[1]:gsub("remote/", "")
     return remote_name
   end
 
-  return head_info.node
+  return commit_info.node
 end
 
----@param head_info HeadInfo
+---@param path string
+---@param ref string
+---@param file string
+---@param start_line number
+---@param end_line number
 ---@return string
-remote_url.blob = function(head_info)
-  local url = head_info.peerurls["default"]:gsub(".git$", "")
-  local object_ref = get_object_ref(head_info)
-
-  return string.format("%s/blob/%s", url, object_ref)
+remote_url.blob = function(path, ref, file, start_line, end_line)
+  local host = path:gsub(".git$", "")
+  return string.format("%s/blob/%s/%s/\\#L%s-L%s", host, ref, file, start_line, end_line)
 end
 
 return remote_url

--- a/lua/sapling_scm_tests/remote_url_spec.lua
+++ b/lua/sapling_scm_tests/remote_url_spec.lua
@@ -2,27 +2,33 @@ require "sapling_scm_tests.setup"
 
 local remote_url = require "sapling_scm.remote_url"
 
-describe("sapling_scm.remote_url.blob", function()
+describe("sapling_scm.remote_url.get_object_ref", function()
   it("returns the node when there is no refs provided", function()
-    local head_info = {
+    local commit_info = {
       node = "9092404705c3763084aa1f18966b1e9e1d1c92b8",
       peerurls = { default = "https://github.com/facebook/sapling.git" },
       remotenames = {},
     }
 
-    assert.is_equal(
-      "https://github.com/facebook/sapling/blob/9092404705c3763084aa1f18966b1e9e1d1c92b8",
-      remote_url.blob(head_info)
-    )
+    assert.is_equal("9092404705c3763084aa1f18966b1e9e1d1c92b8", remote_url.get_object_ref(commit_info))
   end)
 
   it("returns the branch when there is one provided", function()
-    local head_info = {
+    local commit_info = {
       node = "9092404705c3763084aa1f18966b1e9e1d1c92b8",
       peerurls = { default = "https://github.com/facebook/sapling.git" },
       remotenames = { "remote/development" },
     }
 
-    assert.is_equal("https://github.com/facebook/sapling/blob/development", remote_url.blob(head_info))
+    assert.is_equal("development", remote_url.get_object_ref(commit_info))
+  end)
+end)
+
+describe("sapling_scm.remote_url.blob", function()
+  it("returns the correct blob URL for github.com", function()
+    assert.equal(
+      "https://github.com/facebook/sapling/blob/development/README.md/\\#L10-L10",
+      remote_url.blob("https://github.com/facebook/sapling.git", "development", "README.md", 10, 10)
+    )
   end)
 end)

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -61,7 +61,9 @@ vim.api.nvim_create_user_command("Sbrowse", function(props)
   local start_line = props.line1
   local end_line = props.line2
 
-  local host = remote_url.blob(client.head_info())
-  local url = string.format("%s/%s\\#L%s-L%s", host, file, start_line, end_line)
+  local defualt_path = client.config "paths.default"
+  local ref = remote_url.get_object_ref(client.commit_info())
+  local url = remote_url.blob(defualt_path, ref, file, start_line, end_line)
+
   vim.cmd(string.format("silent !xdg-open %s", url))
 end, { range = true, desc = "Browse the current object on the remote url" })


### PR DESCRIPTION
refactor: remote_url.blob to take path, ref and location

Summary:

When getting the URL for a blob we are now getting the host from the config and
not the current commit. This will allow us abstract away the host from the
commit for when we are working with other refs or not using blob urls at all.
This is part of the work to browse the current commit in the browser. This will
also allow us to have different paths for different remotes.

While doing this we have also added a new helper function to the client to
query the config. This will be the same as running `sl config`.

Test Plan:

This has been tested locally and the tests are passing in CI.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/sapling.nvim/pull/14).
* #15
* __->__ #14