### PR TITLE
feat: add support for sapling show urls

### DIFF
--- a/lua/sapling_scm/client.lua
+++ b/lua/sapling_scm/client.lua
@@ -12,8 +12,10 @@ local LOG_COMMAND = [[sl log -r '%s']]
 -- needed to create URLs.
 --
 ---@return CommitInfo
-client.commit_info = function()
-  local commit_info = vim.fn.system [[sl log -r '.' -T"{dict(remotenames,node,peerurls)|json}"]]
+client.commit_info = function(rev)
+  local commit_info =
+    vim.fn.system(string.format([[sl log -r '.' -T"{dict(remotenames,node,peerurls)|json}"]], rev or "."))
+
   return vim.json.decode(commit_info)
 end
 

--- a/lua/sapling_scm/remote_url.lua
+++ b/lua/sapling_scm/remote_url.lua
@@ -1,3 +1,6 @@
+local client = require "sapling_scm.client"
+local fs = require "sapling_scm.fs"
+
 local remote_url = {}
 
 ---@param commit_info CommitInfo
@@ -20,6 +23,38 @@ end
 remote_url.blob = function(path, ref, file, start_line, end_line)
   local host = path:gsub(".git$", "")
   return string.format("%s/blob/%s/%s/\\#L%s-L%s", host, ref, file, start_line, end_line)
+end
+
+---@param path string
+---@param ref string
+---@return string
+remote_url.commit = function(path, ref)
+  local host = path:gsub(".git$", "")
+  return string.format("%s/commit/%s", host, ref)
+end
+
+---@param file_name string
+---@param start_line number
+---@param end_line number
+---@return string
+remote_url.get_url_for_file = function(file_name, start_line, end_line)
+  local default_path = client.config "paths.default"
+  local url
+
+  local parsed = fs.parse_url(file_name)
+  if parsed and parsed.action == "show" then
+    -- The show command can take any revset to show. This will resolve the
+    -- revset into a commit hash so we can send the user to teh correct
+    -- permalink url. This will also prevent us from sending the user to a url
+    -- with a sapling revset in that that hosts don't understand.
+    local rev = client.commit_info(parsed.commit).node
+    url = remote_url.commit(default_path, rev)
+  else
+    local ref = remote_url.get_object_ref(client.commit_info())
+    url = remote_url.blob(default_path, ref, file_name, start_line, end_line)
+  end
+
+  return url
 end
 
 return remote_url

--- a/lua/sapling_scm_tests/remote_url_spec.lua
+++ b/lua/sapling_scm_tests/remote_url_spec.lua
@@ -1,6 +1,9 @@
 require "sapling_scm_tests.setup"
 
 local remote_url = require "sapling_scm.remote_url"
+local client = require "sapling_scm.client"
+
+local stub = require("busted").stub
 
 describe("sapling_scm.remote_url.get_object_ref", function()
   it("returns the node when there is no refs provided", function()
@@ -24,11 +27,68 @@ describe("sapling_scm.remote_url.get_object_ref", function()
   end)
 end)
 
+describe("sapling_scm.remote_url.get_url_for_file", function()
+  stub(client, "config", function(_, _)
+    return "https://github.com/facebook/sapling.git"
+  end)
+
+  stub(client, "commit_info", function(_)
+    return {
+      node = "9092404705c3763084aa1f18966b1e9e1d1c92b8",
+      remotenames = {},
+    }
+  end)
+
+  describe("with a regular file passed in", function()
+    local url = remote_url.get_url_for_file("README.md", 10, 10)
+
+    it("has the correct url for a blob", function()
+      assert.equal(
+        "https://github.com/facebook/sapling/blob/9092404705c3763084aa1f18966b1e9e1d1c92b8/README.md/\\#L10-L10",
+        url
+      )
+    end)
+  end)
+
+  describe("with a sapling show url passed in", function()
+    local url = remote_url.get_url_for_file("sl://show/my-revset", 10, 10)
+
+    it("the commit url is returned", function()
+      assert.equal("https://github.com/facebook/sapling/commit/9092404705c3763084aa1f18966b1e9e1d1c92b8", url)
+    end)
+
+    it("resolves the correct revset from the show url", function()
+      assert.stub(client.commit_info).was_called_with "my-revset"
+    end)
+  end)
+
+  describe("with a dot as the sapling revset", function()
+    local url = remote_url.get_url_for_file("sl://show/.", 10, 10)
+
+    it("the commit url is returned", function()
+      assert.equal("https://github.com/facebook/sapling/commit/9092404705c3763084aa1f18966b1e9e1d1c92b8", url)
+    end)
+
+    it("resolves the correct revset from the show url", function()
+      assert.stub(client.commit_info).was_called_with "."
+    end)
+  end)
+end)
+
 describe("sapling_scm.remote_url.blob", function()
   it("returns the correct blob URL for github.com", function()
     assert.equal(
       "https://github.com/facebook/sapling/blob/development/README.md/\\#L10-L10",
       remote_url.blob("https://github.com/facebook/sapling.git", "development", "README.md", 10, 10)
+    )
+  end)
+end)
+
+describe("sapling_scm.remote_url.commit", function()
+  it("returns the correct blob URL for github.com", function()
+    assert.equal(
+      "https://github.com/facebook/sapling/commit/some-commit-id",
+      remote_url.commit("https://github.com/facebook/sapling.git", "some-commit-id")
     )
   end)
 end)

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -61,9 +61,7 @@ vim.api.nvim_create_user_command("Sbrowse", function(props)
   local start_line = props.line1
   local end_line = props.line2
 
-  local defualt_path = client.config "paths.default"
-  local ref = remote_url.get_object_ref(client.commit_info())
-  local url = remote_url.blob(defualt_path, ref, file, start_line, end_line)
+  local url = remote_url.get_url_for_file(file, start_line, end_line)
 
   vim.cmd(string.format("silent !xdg-open %s", url))
 end, { range = true, desc = "Browse the current object on the remote url" })


### PR DESCRIPTION
feat: add support for sapling show urls

Summary:

When you are in a sapling show buffer, running `:Sbrowse` will now take to to
the commit URL for the current revset. The revset will be resolved to a commit
ID so you will get taken to the correct permalink URL.

Test Plan:

This has been tested manually and there are new tests to cover the new
functionality. This covers both the new commit url format and the full
get_url_for_file function.
