### PR TITLE
fix: remove tailing whitespace from the new lines in commit descriptions

### DIFF
--- a/lua/sapling_scm/fs.lua
+++ b/lua/sapling_scm/fs.lua
@@ -93,7 +93,12 @@ local handle = function(url, buf)
 
     local desc = vim.split(commit.desc, "\n")
     for _, line in ipairs(desc) do
-      vim.api.nvim_buf_set_lines(buf, index, -1, false, { "# " .. line })
+      if #line == 0 then
+        vim.api.nvim_buf_set_lines(buf, index, -1, false, { "#" })
+      else
+        vim.api.nvim_buf_set_lines(buf, index, -1, false, { "# " .. line })
+      end
+
       index = index + 1
     end
 

--- a/lua/sapling_scm_tests/fs_spec.lua
+++ b/lua/sapling_scm_tests/fs_spec.lua
@@ -80,6 +80,10 @@ describe("Sshow", function()
     it("has the buffer file type set to diff", function()
       assert.is_equal("diff", vim.bo.filetype)
     end)
+
+    it("does not have tailing whitespace at the end of the new lines in the description", function()
+      assert.matches("#\n", content)
+    end)
   end)
 end)
 


### PR DESCRIPTION

Summary:

In the Sshow command, it outputs the description of the diff in comments at the
top of the diff. In the new lines there is a tailing whitespace, when you have
highlights that marks tailing whitespace as an error, this can be very
distracting.

Test Plan:

CI, there is a unit test added for this
