### PR TITLE
feat: set the default log rev to be the current stack

### DIFF
--- a/doc/sapling-scm.txt
+++ b/doc/sapling-scm.txt
@@ -39,12 +39,15 @@ Sshow will run `sl show` command with the provided node id. This will put the
 output in a new buffer with the commit description at the top in comments. The
 buffer will have the file type of diff to give you the highlighting.
 
-Slog {revset}                                               *sapling-scm-slog*
+Slog [revset]                                               *sapling-scm-slog*
 
 Run the log command and put the command output into a new buffer. You can
 supply a revset that will be used to filter the log. For now this will use the
 default output of the log command so the output template can be configured
 with `ui.logtemplate` in your sapling config.
+
+Running the log command with no revset will use the default revset of
+`bottom::top` to focus the log to your current stack.
 
 If you have `baleia.nvim` installed all the ANSI escape sequences will be
 colorized in your output as they would in the terminal so you can keep your

--- a/lua/sapling_scm_tests/fs_spec.lua
+++ b/lua/sapling_scm_tests/fs_spec.lua
@@ -59,6 +59,14 @@ describe("Slog", function()
       assert.matches("feat: support showing commits and logging", content)
     end)
   end)
+
+  describe("with no commits", function()
+    run_command "Slog"
+
+    it("uses the default range of the current stack", function()
+      assert.is_equal(vim.fn.expand "%", "sl://log/bottom::top")
+    end)
+  end)
 end)
 
 describe("Sshow", function()

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -29,8 +29,8 @@ vim.api.nvim_create_user_command("Sshow", function(props)
 end, { nargs = "+", desc = "Browse the current object on the remote url" })
 
 vim.api.nvim_create_user_command("Slog", function(props)
-  vim.cmd("edit sl://log/" .. props.args)
-end, { nargs = "+", desc = "Browse the current object on the remote url" })
+  vim.cmd("edit sl://log/" .. coalesce(props.args, "bottom::top"))
+end, { nargs = "?", desc = "Browse the current object on the remote url" })
 
 vim.api.nvim_create_user_command("Sdiff", function(props)
   vim.cmd("edit sl://diff/" .. props.args)


### PR DESCRIPTION

Summary:

Now you can use the `Slog` command with no arguments and it will use the rev
`bottom:top` to focus the log to your current stack.

Test Plan:

CI, unit tests.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/sapling.nvim/pull/18).
* #19
* __->__ #18