### PR TITLE
fix: make urls relative before calling Sbrowse

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -7,4 +7,4 @@ codes = true
 self = false
 
 -- Global objects defined by the C code
-read_globals = { "vim", "describe", "it", "assert", "teardown" }
+read_globals = { "vim", "describe", "it", "assert", "teardown", "spy", "stub", "before_each" }

--- a/doc/sapling-scm.txt
+++ b/doc/sapling-scm.txt
@@ -39,12 +39,15 @@ Sshow will run `sl show` command with the provided node id. This will put the
 output in a new buffer with the commit description at the top in comments. The
 buffer will have the file type of diff to give you the highlighting.
 
-Slog {revset}                                               *sapling-scm-slog*
+Slog [revset]                                               *sapling-scm-slog*
 
 Run the log command and put the command output into a new buffer. You can
 supply a revset that will be used to filter the log. For now this will use the
 default output of the log command so the output template can be configured
 with `ui.logtemplate` in your sapling config.
+
+Running the log command with no revset will use the default revset of
+`bottom::top` to focus the log to your current stack.
 
 If you have `baleia.nvim` installed all the ANSI escape sequences will be
 colorized in your output as they would in the terminal so you can keep your

--- a/lua/sapling_scm_tests/fs_spec.lua
+++ b/lua/sapling_scm_tests/fs_spec.lua
@@ -59,6 +59,14 @@ describe("Slog", function()
       assert.matches("feat: support showing commits and logging", content)
     end)
   end)
+
+  describe("with no commits", function()
+    run_command "Slog"
+
+    it("uses the default range of the current stack", function()
+      assert.is_equal(vim.fn.expand "%", "sl://log/bottom::top")
+    end)
+  end)
 end)
 
 describe("Sshow", function()

--- a/lua/sapling_scm_tests/remote_url_spec.lua
+++ b/lua/sapling_scm_tests/remote_url_spec.lua
@@ -92,3 +92,19 @@ describe("sapling_scm.remote_url.commit", function()
     )
   end)
 end)
+
+describe("remote url integration test", function()
+  local un_stubbed = vim.cmd
+  local match = require "luassert.match"
+
+  before_each(function()
+    vim.cmd("edit " .. os.getenv "PWD" .. "/.github/workflows/test.yml")
+
+    stub(vim, "cmd")
+    un_stubbed "Sbrowse"
+  end)
+
+  it("creates the url from a relative path when the buffer is absolute", function()
+    assert.spy(vim.cmd).was_called_with(match.has_match "/blob/[^/]+/.github/workflows/test.yml")
+  end)
+end)

--- a/lua/sapling_scm_tests/setup.lua
+++ b/lua/sapling_scm_tests/setup.lua
@@ -4,3 +4,6 @@ _G.describe = busted.describe
 _G.it = busted.it
 _G.assert = busted.assert
 _G.teardown = busted.teardown
+_G.spy = busted.spy
+_G.stub = busted.stub
+_G.before_each = busted.before_each

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -29,8 +29,8 @@ vim.api.nvim_create_user_command("Sshow", function(props)
 end, { nargs = "+", desc = "Browse the current object on the remote url" })
 
 vim.api.nvim_create_user_command("Slog", function(props)
-  vim.cmd("edit sl://log/" .. props.args)
-end, { nargs = "+", desc = "Browse the current object on the remote url" })
+  vim.cmd("edit sl://log/" .. coalesce(props.args, "bottom::top"))
+end, { nargs = "?", desc = "Browse the current object on the remote url" })
 
 vim.api.nvim_create_user_command("Sdiff", function(props)
   vim.cmd("edit sl://diff/" .. props.args)

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -71,7 +71,7 @@ else
 end
 
 vim.api.nvim_create_user_command("Sbrowse", function(props)
-  local file = vim.fn.expand "%"
+  local file = vim.fn.expand "%:."
   local start_line = props.line1
   local end_line = props.line2
 


### PR DESCRIPTION

Summary:

When you are in a buffer that has a absolute path as its name. When calling
Sbrowse it will use that hole path in the url. This is obviously incorrect.

Now we are making sure we get the relative path before we create the url so we
don't end up going to a 404.

Test Plan:

CI, unit tests. I have also had the change locally for quite some time.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/sapling.nvim/pull/19).
* __->__ #19
* #18