### PR TITLE
ci: run the tests on more nvim versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     name: Test
+    strategy:
+      matrix:
+        nvim-version: ["v0.9.5", "stable", "nightly"]
     runs-on: ubuntu-latest
     steps:
       - name: Download sapling
@@ -40,7 +43,7 @@ jobs:
         run: |
           test -d _neovim || {
             mkdir -p _neovim
-            curl -sL "https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+            curl -sL "https://github.com/neovim/neovim/releases/download/${{ matrix.nvim-version }}/nvim-linux64.tar.gz" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
 
       - name: Run tests


### PR DESCRIPTION

Summary:

We don't really want to support nvim nightly. I would be good to maintain some
kind of BC with older versions.

Test Plan:

CI
