### PR TITLE
feat: add gd jump support in show and diff buffers

### DIFF
--- a/doc/sapling-scm.txt
+++ b/doc/sapling-scm.txt
@@ -47,6 +47,9 @@ Sshow will run `sl show` command with the provided node id. This will put the
 output in a new buffer with the commit description at the top in comments. The
 buffer will have the file type of diff to give you the highlighting.
 
+While your cursor is on the diff, `gd` will open the file from the shown
+revision at the matching new-side line.
+
 Slog [revset]                                               *sapling-scm-slog*
 
 Run the log command and put the command output into a new buffer. You can
@@ -71,6 +74,9 @@ Sdiff [node]                                               *sapling-scm-sdiff*
 Display the output of the diff command in a buffer. If no arguments are passed
 in then it will show the diff of the current changes. Any arguments passed are
 forwarded to the diff command.
+
+While your cursor is on the diff, `gd` will open the working tree file at the
+matching new-side line.
 
 Sstatus                                                  *sapling-scm-sstatus*
 

--- a/lua/sapling_scm/diff_jump.lua
+++ b/lua/sapling_scm/diff_jump.lua
@@ -1,0 +1,284 @@
+local diff_jump = {}
+
+local normalize_diff_path = function(path)
+  if path == "/dev/null" then
+    return nil
+  end
+
+  if path:sub(1, 1) == '"' and path:sub(-1) == '"' then
+    path = path:sub(2, -2):gsub('\\"', '"')
+  end
+
+  if path:sub(1, 2) == "a/" or path:sub(1, 2) == "b/" then
+    return path:sub(3)
+  end
+
+  return path
+end
+
+---@param line string
+---@return table | nil
+local parse_hunk_header = function(line)
+  local old_start, old_count, new_start, new_count = line:match "^@@ %-(%d+),?(%d*) %+(%d+),?(%d*) @@"
+  if not old_start then
+    return nil
+  end
+
+  local normalize_count = function(count)
+    if count == "" then
+      return 1
+    end
+
+    return tonumber(count)
+  end
+
+  return {
+    old_start = tonumber(old_start),
+    old_count = normalize_count(old_count),
+    new_start = tonumber(new_start),
+    new_count = normalize_count(new_count),
+  }
+end
+
+---@param line string
+---@return string
+local classify_diff_line = function(line)
+  if line:match [[^\\ No newline at end of file$]] then
+    return "meta"
+  end
+
+  local prefix = line:sub(1, 1)
+  if prefix == "+" then
+    return "add"
+  end
+
+  if prefix == "-" then
+    return "remove"
+  end
+
+  if prefix == " " then
+    return "context"
+  end
+
+  return "other"
+end
+
+---@param lines string[]
+---@param cursor_line number
+---@return number | nil, number | nil
+local find_file_bounds = function(lines, cursor_line)
+  local start_line
+  for line_number = cursor_line, 1, -1 do
+    if lines[line_number]:match "^diff %-%-git " then
+      start_line = line_number
+      break
+    end
+  end
+
+  if not start_line then
+    return nil, nil
+  end
+
+  local end_line = #lines
+  for line_number = start_line + 1, #lines do
+    if lines[line_number]:match "^diff %-%-git " then
+      end_line = line_number - 1
+      break
+    end
+  end
+
+  return start_line, end_line
+end
+
+---@param lines string[]
+---@param start_line number
+---@param end_line number
+---@return string | nil
+local find_new_path = function(lines, start_line, end_line)
+  for line_number = start_line, end_line do
+    local path = lines[line_number]:match "^%+%+%+ (.*)$"
+    if path then
+      return normalize_diff_path(path)
+    end
+  end
+
+  return nil
+end
+
+---@param lines string[]
+---@param start_line number
+---@param end_line number
+---@param cursor_line number
+---@return number | nil, table | nil
+local find_hunk = function(lines, start_line, end_line, cursor_line)
+  for line_number = cursor_line, start_line, -1 do
+    local hunk = parse_hunk_header(lines[line_number])
+    if hunk then
+      return line_number, hunk
+    end
+  end
+
+  for line_number = start_line, end_line do
+    local hunk = parse_hunk_header(lines[line_number])
+    if hunk then
+      return line_number, hunk
+    end
+  end
+
+  return nil, nil
+end
+
+---@param lines string[]
+---@param cursor_line number
+---@return { file: string, line: number } | nil, string | nil
+function diff_jump.location_from_lines(lines, cursor_line)
+  local start_line, end_line = find_file_bounds(lines, cursor_line)
+  if not start_line or not end_line then
+    return nil, "no diff target found on this line"
+  end
+
+  local file = find_new_path(lines, start_line, end_line)
+  if not file then
+    return nil, "no new-side target for this file"
+  end
+
+  local hunk_line, hunk = find_hunk(lines, start_line, end_line, cursor_line)
+  if not hunk_line or not hunk then
+    return nil, "no hunk target found for this file"
+  end
+
+  local target_line = hunk.new_start
+  for line_number = hunk_line + 1, cursor_line - 1 do
+    local kind = classify_diff_line(lines[line_number])
+    if kind == "add" or kind == "context" then
+      target_line = target_line + 1
+    end
+  end
+
+  return { file = file, line = target_line }, nil
+end
+
+---@param buf integer
+---@return { action: string, commit: string | nil } | nil
+local get_buffer_source = function(buf)
+  local ok_action, action = pcall(vim.api.nvim_buf_get_var, buf, "sapling_diff_action")
+  if ok_action and action then
+    local ok_commit, commit = pcall(vim.api.nvim_buf_get_var, buf, "sapling_show_commit")
+    return { action = action, commit = ok_commit and commit or nil }
+  end
+
+  local name = vim.api.nvim_buf_get_name(buf)
+  local show_commit = name:match "^sl://show/(.*)$"
+  if show_commit then
+    return { action = "show", commit = show_commit }
+  end
+
+  if name:match "^sl://diff/" then
+    return { action = "diff", commit = nil }
+  end
+
+  return nil
+end
+
+---@param buf integer
+---@param cursor_line number
+---@return { action: string, file: string, line: number, path: string | nil, url: string | nil } | nil, string | nil
+function diff_jump.target_from_buffer(buf, cursor_line)
+  local source = get_buffer_source(buf)
+  if not source then
+    return nil, "not a sapling diff buffer"
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local location, err = diff_jump.location_from_lines(lines, cursor_line)
+  if not location then
+    return nil, err
+  end
+
+  if source.action == "show" then
+    if not source.commit then
+      return nil, "no shown revision found for this buffer"
+    end
+
+    return {
+      action = "show",
+      file = location.file,
+      line = location.line,
+      path = nil,
+      url = string.format("sl://cat/%s/%s", source.commit, location.file),
+    },
+      nil
+  end
+
+  return {
+    action = "diff",
+    file = location.file,
+    line = location.line,
+    path = location.file,
+    url = nil,
+  },
+    nil
+end
+
+---@param current_win integer
+---@return integer
+local find_destination_window = function(current_win)
+  local previous_window_number = vim.fn.winnr "#"
+  if previous_window_number > 0 then
+    local previous_window = vim.fn.win_getid(previous_window_number)
+    if previous_window ~= current_win and vim.api.nvim_win_is_valid(previous_window) then
+      local previous_buffer = vim.api.nvim_win_get_buf(previous_window)
+      local previous_name = vim.api.nvim_buf_get_name(previous_buffer)
+      if not previous_name:match "^sl://" then
+        return previous_window
+      end
+    end
+  end
+
+  for _, window in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if window ~= current_win then
+      local buffer = vim.api.nvim_win_get_buf(window)
+      local name = vim.api.nvim_buf_get_name(buffer)
+      if not name:match "^sl://" then
+        return window
+      end
+    end
+  end
+
+  return current_win
+end
+
+---@param line_number number
+local set_cursor = function(line_number)
+  local line_count = vim.api.nvim_buf_line_count(0)
+  local clamped = math.max(1, math.min(line_number, line_count))
+  vim.api.nvim_win_set_cursor(0, { clamped, 0 })
+end
+
+function diff_jump.jump()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local target, err = diff_jump.target_from_buffer(vim.api.nvim_get_current_buf(), cursor[1])
+  if not target then
+    vim.notify("Sapling: " .. err, vim.log.levels.INFO)
+    return false
+  end
+
+  vim.api.nvim_set_current_win(find_destination_window(vim.api.nvim_get_current_win()))
+
+  if target.action == "show" and target.url then
+    vim.cmd("edit " .. vim.fn.fnameescape(target.url))
+    set_cursor(target.line)
+    return true
+  end
+
+  if target.path then
+    vim.cmd("edit " .. vim.fn.fnameescape(target.path))
+    set_cursor(target.line)
+    return true
+  end
+
+  vim.notify("Sapling: no jump target found", vim.log.levels.INFO)
+  return false
+end
+
+return diff_jump

--- a/lua/sapling_scm/fs.lua
+++ b/lua/sapling_scm/fs.lua
@@ -13,6 +13,29 @@ local highlight_buffer = function(buf)
   end
 end
 
+---@param buf integer
+---@param action string
+---@param commit string | nil
+local configure_diff_buffer = function(buf, action, commit)
+  vim.api.nvim_buf_set_var(buf, "sapling_diff_action", action)
+
+  if commit then
+    vim.api.nvim_buf_set_var(buf, "sapling_show_commit", commit)
+  else
+    pcall(vim.api.nvim_buf_del_var, buf, "sapling_show_commit")
+  end
+
+  vim.keymap.set("n", "gd", function()
+    require("sapling_scm.diff_jump").jump()
+  end, {
+    noremap = true,
+    silent = true,
+    nowait = true,
+    buffer = buf,
+    desc = "Jump to the new-side location from the current sapling diff",
+  })
+end
+
 ---@alias action "show" | "log"
 
 ---@class ShowAction
@@ -83,6 +106,7 @@ local handle = function(url, buf)
     local commit = client.show(action.commit)
 
     vim.api.nvim_buf_set_option(buf, "filetype", "diff")
+    configure_diff_buffer(buf, "show", commit.node)
 
     local header = {
       "# Node: " .. commit.node,
@@ -128,6 +152,7 @@ local handle = function(url, buf)
   if action.action == "diff" then
     local diff = client.diff(action.pattern)
     vim.api.nvim_buf_set_option(buf, "filetype", "diff")
+    configure_diff_buffer(buf, "diff", nil)
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, diff)
   end
 

--- a/lua/sapling_scm_tests/diff_jump_spec.lua
+++ b/lua/sapling_scm_tests/diff_jump_spec.lua
@@ -1,0 +1,160 @@
+require "sapling_scm_tests.setup"
+
+local diff_jump = require "sapling_scm.diff_jump"
+
+local find_line_number = function(lines, needle)
+  for line_number, line in ipairs(lines) do
+    if line == needle then
+      return line_number
+    end
+  end
+
+  return nil
+end
+
+local create_buffer = function(name, lines, vars)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_name(buf, name)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+  for key, value in pairs(vars or {}) do
+    vim.api.nvim_buf_set_var(buf, key, value)
+  end
+
+  return buf
+end
+
+describe("diff_jump.location_from_lines", function()
+  local lines = {
+    "diff --git a/lua/test.lua b/lua/test.lua",
+    "--- a/lua/test.lua",
+    "+++ b/lua/test.lua",
+    "@@ -10,3 +10,4 @@",
+    " local one = 1",
+    "-local two = 2",
+    "+local two = 3",
+    " local three = 3",
+  }
+
+  it("jumps to the hunk start from the file header", function()
+    local location = assert(diff_jump.location_from_lines(lines, 1))
+    assert.are.same({ file = "lua/test.lua", line = 10 }, location)
+  end)
+
+  it("maps removed lines to the new-side insertion point", function()
+    local location = assert(diff_jump.location_from_lines(lines, 6))
+    assert.are.same({ file = "lua/test.lua", line = 11 }, location)
+  end)
+
+  it("maps added lines to the new-side line", function()
+    local location = assert(diff_jump.location_from_lines(lines, 7))
+    assert.are.same({ file = "lua/test.lua", line = 11 }, location)
+  end)
+
+  it("maps later context lines after additions", function()
+    local location = assert(diff_jump.location_from_lines(lines, 8))
+    assert.are.same({ file = "lua/test.lua", line = 12 }, location)
+  end)
+
+  it("refuses to jump to deleted files", function()
+    local _, err = diff_jump.location_from_lines({
+      "diff --git a/lua/test.lua b/lua/test.lua",
+      "deleted file mode 100644",
+      "--- a/lua/test.lua",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-local deleted = true",
+    }, 6)
+
+    assert.is_equal("no new-side target for this file", err)
+  end)
+end)
+
+describe("diff_jump.target_from_buffer", function()
+  it("builds a working tree target for Sdiff buffers", function()
+    local buf = create_buffer("sl://diff/-r a -r b", {
+      "diff --git a/lua/test.lua b/lua/test.lua",
+      "--- a/lua/test.lua",
+      "+++ b/lua/test.lua",
+      "@@ -1 +1 @@",
+      "+local test = true",
+    })
+
+    local target = assert(diff_jump.target_from_buffer(buf, 5))
+
+    assert.are.same({
+      action = "diff",
+      file = "lua/test.lua",
+      line = 1,
+      path = "lua/test.lua",
+      url = nil,
+    }, target)
+  end)
+
+  it("builds a cat target for Sshow buffers", function()
+    local buf = create_buffer("sl://show/.", {
+      "# Node: abcdef",
+      "diff --git a/lua/test.lua b/lua/test.lua",
+      "--- a/lua/test.lua",
+      "+++ b/lua/test.lua",
+      "@@ -1 +1 @@",
+      "+local test = true",
+    }, {
+      sapling_diff_action = "show",
+      sapling_show_commit = "abcdef123456",
+    })
+
+    local target = assert(diff_jump.target_from_buffer(buf, 6))
+
+    assert.are.same({
+      action = "show",
+      file = "lua/test.lua",
+      line = 1,
+      path = nil,
+      url = "sl://cat/abcdef123456/lua/test.lua",
+    }, target)
+  end)
+end)
+
+describe("diff_jump.jump", function()
+  describe("from Sdiff", function()
+    vim.fn.system "echo 'This is a line added' >> README.md"
+    vim.cmd "Sdiff"
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    local line_number = assert(find_line_number(lines, "+This is a line added"))
+    vim.api.nvim_win_set_cursor(0, { line_number, 0 })
+
+    diff_jump.jump()
+
+    teardown(function()
+      vim.fn.system "sl revert README.md"
+    end)
+
+    it("opens the working tree file", function()
+      assert.is_equal("README.md", vim.fn.expand "%:t")
+    end)
+
+    it("jumps to the matching line", function()
+      assert.is_equal("This is a line added", vim.api.nvim_get_current_line())
+    end)
+  end)
+
+  describe("from Sshow", function()
+    vim.cmd "Sshow f5bdd00322fe"
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    local line_number = assert(find_line_number(lines, "+local client = {}"))
+    vim.api.nvim_win_set_cursor(0, { line_number, 0 })
+
+    diff_jump.jump()
+
+    it("opens the file at the shown revision", function()
+      assert.matches("^sl://cat/.*/lua/sapling_scm/client.lua$", vim.fn.expand "%")
+    end)
+
+    it("jumps to the matching line", function()
+      assert.is_equal("local client = {}", vim.api.nvim_get_current_line())
+    end)
+  end)
+end)


### PR DESCRIPTION

Summary:

When reviewing a patch you can now push `gd` to open the matching
new-side location in the code. This works in `:Sdiff` against the
working tree and in `:Sshow` against the shown revision via `sl://cat`.

The jump code parses the current file and hunk, maps removed lines to
the new-side insertion point and refuses to jump when there is no
new-side target, such as deleted files. Tests and help docs have been
added for the new behaviour.

Test Plan:

1. Run `luac -p lua/sapling_scm/diff_jump.lua && luac -p
lua/sapling_scm/fs.lua && luac -p
lua/sapling_scm_tests/diff_jump_spec.lua`.
2. Open `nvim`, run `:Sdiff`, place the cursor on a changed line and
push `gd`.
3. Open `nvim`, run `:Sshow f5bdd00322fe`, place the cursor on a
changed line and push `gd`.
