### PR TITLE
feat: add Sedit command for working copy jumps

### DIFF
--- a/doc/sapling-scm.txt
+++ b/doc/sapling-scm.txt
@@ -13,6 +13,7 @@ CONTENTS                                                *sapling-scm-contents*
   2.6 Sannotate                                        |sapling-scm-sannotate|
   2.7 Scommit                                            |sapling-scm-scommit|
   2.8 Sbrowse                                            |sapling-scm-sbrowse|
+  2.9 Sedit                                                |sapling-scm-sedit|
 3. Log Actions                                       |sapling-scm-log-actions|
   3.1 View                                              |sapling-scm-log-view|
   3.2 Metaedit                                      |sapling-scm-log-metaedit|
@@ -115,6 +116,15 @@ be inferred from your current remote name that is linked to your current
 commit, falling back to the node.
 
 NOTE: Currently only GitHub is supported
+
+Sedit                                                      *sapling-scm-sedit*
+
+Open the working copy for the file under your cursor.
+
+From a `Scat` buffer it will open the same file at the current line.
+
+From `Sshow` and `Sdiff` diff buffers it will open the working copy file at
+the matching new-side line.
 
 ==============================================================================
 LOG ACTIONS                                          *sapling-scm-log-actions*

--- a/lua/sapling_scm/client.lua
+++ b/lua/sapling_scm/client.lua
@@ -122,6 +122,16 @@ client.status = function()
   return vim.json.decode(vim.fn.system "sl status -Tjson")
 end
 
+---@return string | nil
+client.root = function()
+  local root = vim.trim(vim.fn.system "sl root")
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+
+  return root
+end
+
 -- Gets an entry from the local config. You can pass in the dot separated path
 -- and it will return that value from the users local config of the repo.
 ---@param path string

--- a/lua/sapling_scm/diff_jump.lua
+++ b/lua/sapling_scm/diff_jump.lua
@@ -1,3 +1,5 @@
+local client = require "sapling_scm.client"
+
 local diff_jump = {}
 
 local normalize_diff_path = function(path)
@@ -159,22 +161,27 @@ function diff_jump.location_from_lines(lines, cursor_line)
 end
 
 ---@param buf integer
----@return { action: string, commit: string | nil } | nil
+---@return { action: string, commit: string | nil, file: string | nil } | nil
 local get_buffer_source = function(buf)
   local ok_action, action = pcall(vim.api.nvim_buf_get_var, buf, "sapling_diff_action")
   if ok_action and action then
     local ok_commit, commit = pcall(vim.api.nvim_buf_get_var, buf, "sapling_show_commit")
-    return { action = action, commit = ok_commit and commit or nil }
+    return { action = action, commit = ok_commit and commit or nil, file = nil }
   end
 
   local name = vim.api.nvim_buf_get_name(buf)
   local show_commit = name:match "^sl://show/(.*)$"
   if show_commit then
-    return { action = "show", commit = show_commit }
+    return { action = "show", commit = show_commit, file = nil }
   end
 
   if name:match "^sl://diff/" then
-    return { action = "diff", commit = nil }
+    return { action = "diff", commit = nil, file = nil }
+  end
+
+  local _, cat_file = name:match "^sl://cat/([^/]+)/(.*)$"
+  if cat_file then
+    return { action = "cat", commit = nil, file = cat_file }
   end
 
   return nil
@@ -185,7 +192,7 @@ end
 ---@return { action: string, file: string, line: number, path: string | nil, url: string | nil } | nil, string | nil
 function diff_jump.target_from_buffer(buf, cursor_line)
   local source = get_buffer_source(buf)
-  if not source then
+  if not source or source.action == "cat" then
     return nil, "not a sapling diff buffer"
   end
 
@@ -218,6 +225,30 @@ function diff_jump.target_from_buffer(buf, cursor_line)
     url = nil,
   },
     nil
+end
+
+---@param buf integer
+---@param cursor_line number
+---@return { file: string, line: number } | nil, string | nil
+function diff_jump.working_copy_target_from_buffer(buf, cursor_line)
+  local source = get_buffer_source(buf)
+  if not source then
+    return nil, "not a sapling buffer"
+  end
+
+  if source.action == "cat" then
+    if not source.file then
+      return nil, "no file found for this buffer"
+    end
+
+    return {
+      file = source.file,
+      line = cursor_line,
+    }, nil
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  return diff_jump.location_from_lines(lines, cursor_line)
 end
 
 ---@param current_win integer
@@ -255,6 +286,38 @@ local set_cursor = function(line_number)
   vim.api.nvim_win_set_cursor(0, { clamped, 0 })
 end
 
+---@param file string
+---@return string | nil, string | nil
+local resolve_working_copy_path = function(file)
+  local root = client.root()
+  if not root or root == "" then
+    return nil, "could not determine repository root"
+  end
+
+  local path = vim.fn.simplify(root .. "/" .. file)
+  if vim.fn.filereadable(path) ~= 1 then
+    return nil, "working copy file not found: " .. file
+  end
+
+  return path, nil
+end
+
+---@param destination_window integer
+---@param target { file: string, line: number }
+---@return boolean, string | nil
+local open_working_copy_target = function(destination_window, target)
+  local path, err = resolve_working_copy_path(target.file)
+  if not path then
+    return false, err
+  end
+
+  vim.api.nvim_set_current_win(destination_window)
+  vim.cmd("edit " .. vim.fn.fnameescape(path))
+  set_cursor(target.line)
+
+  return true, nil
+end
+
 function diff_jump.jump()
   local cursor = vim.api.nvim_win_get_cursor(0)
   local target, err = diff_jump.target_from_buffer(vim.api.nvim_get_current_buf(), cursor[1])
@@ -263,21 +326,46 @@ function diff_jump.jump()
     return false
   end
 
-  vim.api.nvim_set_current_win(find_destination_window(vim.api.nvim_get_current_win()))
+  local destination_window = find_destination_window(vim.api.nvim_get_current_win())
 
   if target.action == "show" and target.url then
+    vim.api.nvim_set_current_win(destination_window)
     vim.cmd("edit " .. vim.fn.fnameescape(target.url))
     set_cursor(target.line)
     return true
   end
 
-  if target.path then
-    vim.cmd("edit " .. vim.fn.fnameescape(target.path))
-    set_cursor(target.line)
-    return true
+  if target.file then
+    local ok, open_err = open_working_copy_target(destination_window, {
+      file = target.file,
+      line = target.line,
+    })
+    if ok then
+      return true
+    end
+
+    vim.notify("Sapling: " .. open_err, vim.log.levels.INFO)
+    return false
   end
 
   vim.notify("Sapling: no jump target found", vim.log.levels.INFO)
+  return false
+end
+
+function diff_jump.edit_working_copy()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local target, err = diff_jump.working_copy_target_from_buffer(vim.api.nvim_get_current_buf(), cursor[1])
+  if not target then
+    vim.notify("Sapling: " .. err, vim.log.levels.INFO)
+    return false
+  end
+
+  local ok, open_err = open_working_copy_target(find_destination_window(vim.api.nvim_get_current_win()), target)
+  if ok then
+    return true
+  end
+
+  vim.notify("Sapling: " .. open_err, vim.log.levels.INFO)
   return false
 end
 

--- a/lua/sapling_scm_tests/diff_jump_spec.lua
+++ b/lua/sapling_scm_tests/diff_jump_spec.lua
@@ -1,5 +1,6 @@
 require "sapling_scm_tests.setup"
 
+local client = require "sapling_scm.client"
 local diff_jump = require "sapling_scm.diff_jump"
 
 local find_line_number = function(lines, needle)
@@ -22,6 +23,22 @@ local create_buffer = function(name, lines, vars)
   end
 
   return buf
+end
+
+local run_with_cwd = function(path, callback)
+  local previous_cwd = vim.fn.getcwd()
+  local ok, result = xpcall(function()
+    vim.cmd("cd " .. vim.fn.fnameescape(path))
+    return callback()
+  end, debug.traceback)
+
+  vim.cmd("cd " .. vim.fn.fnameescape(previous_cwd))
+
+  if not ok then
+    error(result)
+  end
+
+  return result
 end
 
 describe("diff_jump.location_from_lines", function()
@@ -116,6 +133,22 @@ describe("diff_jump.target_from_buffer", function()
   end)
 end)
 
+describe("diff_jump.working_copy_target_from_buffer", function()
+  it("builds a working copy target for Scat buffers", function()
+    local buf = create_buffer("sl://cat/abcdef123456/lua/test.lua", {
+      "local test = true",
+      "return test",
+    })
+
+    local target = assert(diff_jump.working_copy_target_from_buffer(buf, 2))
+
+    assert.are.same({
+      file = "lua/test.lua",
+      line = 2,
+    }, target)
+  end)
+end)
+
 describe("diff_jump.jump", function()
   describe("from Sdiff", function()
     vim.fn.system "echo 'This is a line added' >> README.md"
@@ -140,6 +173,28 @@ describe("diff_jump.jump", function()
     end)
   end)
 
+  it("opens the working tree file away from the repo root", function()
+    local root = assert(client.root())
+    local expected_line = assert(vim.fn.readfile(root .. "/doc/sapling-scm.txt")[1])
+    local buf = create_buffer("sl://diff/root-aware", {
+      "diff --git a/doc/sapling-scm.txt b/doc/sapling-scm.txt",
+      "--- a/doc/sapling-scm.txt",
+      "+++ b/doc/sapling-scm.txt",
+      "@@ -1 +1 @@",
+      "+" .. expected_line,
+    })
+
+    run_with_cwd(root .. "/doc", function()
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 5, 0 })
+
+      assert.is_true(diff_jump.jump())
+    end)
+
+    assert.is_truthy(vim.api.nvim_buf_get_name(0):match "/doc/sapling%-scm.txt$")
+    assert.is_equal(expected_line, vim.api.nvim_get_current_line())
+  end)
+
   describe("from Sshow", function()
     vim.cmd "Sshow f5bdd00322fe"
 
@@ -156,5 +211,38 @@ describe("diff_jump.jump", function()
     it("jumps to the matching line", function()
       assert.is_equal("local client = {}", vim.api.nvim_get_current_line())
     end)
+  end)
+end)
+
+describe("Sedit", function()
+  it("opens the working copy file from Sshow", function()
+    local root = assert(client.root())
+
+    run_with_cwd(root .. "/doc", function()
+      vim.cmd "Sshow f5bdd00322fe"
+
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      local line_number = assert(find_line_number(lines, "+local client = {}"))
+      vim.api.nvim_win_set_cursor(0, { line_number, 0 })
+
+      vim.cmd "Sedit"
+    end)
+
+    assert.matches("/lua/sapling_scm/client.lua$", vim.api.nvim_buf_get_name(0))
+    assert.is_equal("local client = {}", vim.api.nvim_get_current_line())
+  end)
+
+  it("opens the working copy file from Scat", function()
+    local root = assert(client.root())
+
+    run_with_cwd(root .. "/doc", function()
+      vim.cmd "edit sl://cat/f5bdd00322fe/lua/sapling_scm/client.lua"
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      vim.cmd "Sedit"
+    end)
+
+    assert.matches("/lua/sapling_scm/client.lua$", vim.api.nvim_buf_get_name(0))
+    assert.is_equal("local client = {}", vim.api.nvim_get_current_line())
   end)
 end)

--- a/plugin/sapling_scm.lua
+++ b/plugin/sapling_scm.lua
@@ -66,6 +66,10 @@ vim.api.nvim_create_user_command("Scat", function(props)
   vim.cmd(string.format("edit sl://cat/%s/%s", props.fargs[1], props.fargs[2] or vim.fn.expand "%"))
 end, { nargs = "?", desc = "View a file at a revision" })
 
+vim.api.nvim_create_user_command("Sedit", function()
+  require("sapling_scm.diff_jump").edit_working_copy()
+end, { desc = "Open the working copy for the current Sapling buffer location" })
+
 vim.api.nvim_create_user_command("Sannotate", function(props)
   local width, annotations = client.annotate(coalesce(props.args, "."), vim.api.nvim_buf_get_name(0))
 


### PR DESCRIPTION

Summary:

When reviewing history you can now run `:Sedit` to leave a Sapling
buffer and open the working copy for that file at the matching line.
This makes it easier to move from `:Sshow` and `:Scat` into an
editable buffer without manually finding the file again.

The jump code now recognises `sl://cat` buffers, resolves working
copy paths from `sl root` and reuses that path handling for working
copy jumps from `:Sdiff`. Tests and help docs have been added for the
new command and the repo-root-aware behaviour.

Test Plan:

1. Run `luac -p lua/sapling_scm/client.lua && luac -p
lua/sapling_scm/diff_jump.lua && luac -p
lua/sapling_scm_tests/diff_jump_spec.lua && luac -p
plugin/sapling_scm.lua`.
2. Run `nvim -u NONE --headless '+set rtp+=.' '+lua
require("plugin.sapling_scm")' '+cd lua' '+Sshow f5bdd00322fe'
'+lua local lines=vim.api.nvim_buf_get_lines(0,0,-1,false); for
i,l in ipairs(lines) do if l=="+local client = {}" then
vim.api.nvim_win_set_cursor(0,{i,0}); break end end' '+Sedit'
'+lua assert(vim.fn.expand("%"):match("/lua/sapling_scm/client.lua$"))'
'+lua assert(vim.api.nvim_get_current_line() == "local client = {}")'
+qa`.
3. Run `nvim -u NONE --headless '+set rtp+=.' '+lua
require("plugin.sapling_scm")' '+cd lua' '+edit
sl://cat/f5bdd00322fe/lua/sapling_scm/client.lua' '+1' '+Sedit'
'+lua assert(vim.fn.expand("%"):match("/lua/sapling_scm/client.lua$"))'
'+lua assert(vim.api.nvim_get_current_line() == "local client = {}")'
+qa`.
